### PR TITLE
add propertyNameResolver option

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,65 +37,70 @@ function generateInterface(className, input, options) {
     var definition = 'interface ' + className + ' {\n';
 
     var propertyResult;
-    
+
     var prefixFieldsWithI = options && options.prefixWithI;
-    
+    var propertyNameResolver = options && options.propertyNameResolver;
+
     if (options && options.dateTimeToDate) {
       typeTranslation.DateTime = 'Date';
     } else {
       typeTranslation.DateTime = 'string';
     }
-    
+
     while (!!(propertyResult = propertyRegex.exec(input))) {
         var varType = typeTranslation[propertyResult[1]];
-        
+
         var isOptional = propertyResult[2] === '?';
 
         if (!varType) {
             varType = propertyResult[1];
-            
+
             var collectionMatch = collectionRegex.exec(varType);
             var arrayMatch = arrayRegex.exec(varType);
-            
+
             if (collectionMatch) {
                 var collectionType = collectionMatch[1];
-                
+
                 if (typeTranslation[collectionType]) {
                     varType = typeTranslation[collectionType];
                 } else {
                     varType = collectionType;
-                                        
+
                     if (prefixFieldsWithI) {
                         varType = 'I' + varType;
                     }
                 }
-                
+
                 varType += '[]';
             } else if (arrayMatch) {
                 var arrayType = arrayMatch[1];
-                
+
                 if (typeTranslation[arrayType]) {
                     varType = typeTranslation[arrayType];
                 } else {
                     varType = arrayType;
-                    
+
                     if (prefixFieldsWithI) {
                         varType = 'I' + varType;
                     }
                 }
-                
+
                 varType += '[]';
             } else if (prefixFieldsWithI) {
                 varType = 'I' + varType;
             }
         }
 
-        definition += '    ' + propertyResult[3];
-        
+        var propertyName = propertyResult[3];
+        if (propertyNameResolver) {
+          propertyName = propertyNameResolver(propertyName);
+        }
+        definition += '    ' + propertyName;
+
         if (isOptional) {
             definition += '?';
         }
-        
+
         definition += ': ' + varType + ';\n';
     }
 
@@ -107,36 +112,36 @@ function generateInterface(className, input, options) {
 function generateEnum(enumName, input, options) {
     var entryRegex = /([^\s,]+)\s*=?\s*(\d+)?,?/gm;
     var definition = 'enum ' + enumName + ' { ';
-    
+
     var entryResult;
-    
+
     var elements = [];
     var lastIndex = 0;
-    
+
     while(!!(entryResult = entryRegex.exec(input))) {
         var entryName = entryResult[1];
         var entryValue = entryResult[2];
-        
+
         // Skip attributes, might be a cleaner way in the regex
         if (entryName.indexOf('[') !== -1) {
             continue;
         }
-        
+
         if (!entryValue) {
             entryValue = lastIndex;
-            
+
             lastIndex++;
         } else {
             lastIndex = parseInt(entryValue, 10) + 1;
         }
-        
+
         elements.push(entryName + ' = ' + entryValue);
     }
-    
+
     definition += elements.join(', ');
-    
+
     definition += ' }\n';
-    
+
     return definition;
 }
 
@@ -176,9 +181,9 @@ module.exports = function(input, options) {
             result += generateEnum(typeName, match[5], options);
         }
     }
-    
+
     if (options.baseNamespace) {
-        var firstLine; 
+        var firstLine;
 
         if (options.definitionFile === false) {
             firstLine = 'module ' + options.baseNamespace + ' {';
@@ -187,17 +192,16 @@ module.exports = function(input, options) {
         }
 
         var lines = [firstLine];
-        
+
         lines = lines.concat(result.split('\n').map(function(line) {
             return '    ' + (/^(?:interface|enum)/.test(line) ? 'export ' + line : line);
         }));
         lines = lines.slice(0, lines.length - 1);
         lines = lines.concat('}');
-        
+
         result = lines.join('\n');
     }
-    
+
     // TODO: Error?  Is this ok?
     return result;
 };
-

--- a/index.js
+++ b/index.js
@@ -37,54 +37,54 @@ function generateInterface(className, input, options) {
     var definition = 'interface ' + className + ' {\n';
 
     var propertyResult;
-
+    
     var prefixFieldsWithI = options && options.prefixWithI;
     var propertyNameResolver = options && options.propertyNameResolver;
-
+    
     if (options && options.dateTimeToDate) {
       typeTranslation.DateTime = 'Date';
     } else {
       typeTranslation.DateTime = 'string';
     }
-
+    
     while (!!(propertyResult = propertyRegex.exec(input))) {
         var varType = typeTranslation[propertyResult[1]];
-
+        
         var isOptional = propertyResult[2] === '?';
 
         if (!varType) {
             varType = propertyResult[1];
-
+            
             var collectionMatch = collectionRegex.exec(varType);
             var arrayMatch = arrayRegex.exec(varType);
-
+            
             if (collectionMatch) {
                 var collectionType = collectionMatch[1];
-
+                
                 if (typeTranslation[collectionType]) {
                     varType = typeTranslation[collectionType];
                 } else {
                     varType = collectionType;
-
+                                        
                     if (prefixFieldsWithI) {
                         varType = 'I' + varType;
                     }
                 }
-
+                
                 varType += '[]';
             } else if (arrayMatch) {
                 var arrayType = arrayMatch[1];
-
+                
                 if (typeTranslation[arrayType]) {
                     varType = typeTranslation[arrayType];
                 } else {
                     varType = arrayType;
-
+                    
                     if (prefixFieldsWithI) {
                         varType = 'I' + varType;
                     }
                 }
-
+                
                 varType += '[]';
             } else if (prefixFieldsWithI) {
                 varType = 'I' + varType;
@@ -96,11 +96,11 @@ function generateInterface(className, input, options) {
           propertyName = propertyNameResolver(propertyName);
         }
         definition += '    ' + propertyName;
-
+        
         if (isOptional) {
             definition += '?';
         }
-
+        
         definition += ': ' + varType + ';\n';
     }
 
@@ -112,36 +112,36 @@ function generateInterface(className, input, options) {
 function generateEnum(enumName, input, options) {
     var entryRegex = /([^\s,]+)\s*=?\s*(\d+)?,?/gm;
     var definition = 'enum ' + enumName + ' { ';
-
+    
     var entryResult;
-
+    
     var elements = [];
     var lastIndex = 0;
-
+    
     while(!!(entryResult = entryRegex.exec(input))) {
         var entryName = entryResult[1];
         var entryValue = entryResult[2];
-
+        
         // Skip attributes, might be a cleaner way in the regex
         if (entryName.indexOf('[') !== -1) {
             continue;
         }
-
+        
         if (!entryValue) {
             entryValue = lastIndex;
-
+            
             lastIndex++;
         } else {
             lastIndex = parseInt(entryValue, 10) + 1;
         }
-
+        
         elements.push(entryName + ' = ' + entryValue);
     }
-
+    
     definition += elements.join(', ');
-
+    
     definition += ' }\n';
-
+    
     return definition;
 }
 
@@ -181,7 +181,7 @@ module.exports = function(input, options) {
             result += generateEnum(typeName, match[5], options);
         }
     }
-
+    
     if (options.baseNamespace) {
         var firstLine;
 
@@ -192,16 +192,16 @@ module.exports = function(input, options) {
         }
 
         var lines = [firstLine];
-
+        
         lines = lines.concat(result.split('\n').map(function(line) {
             return '    ' + (/^(?:interface|enum)/.test(line) ? 'export ' + line : line);
         }));
         lines = lines.slice(0, lines.length - 1);
         lines = lines.concat('}');
-
+        
         result = lines.join('\n');
     }
-
+    
     // TODO: Error?  Is this ok?
     return result;
 };

--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ module.exports = function(input, options) {
     }
     
     if (options.baseNamespace) {
-        var firstLine;
+        var firstLine; 
 
         if (options.definitionFile === false) {
             firstLine = 'module ' + options.baseNamespace + ' {';

--- a/spec/propertyNameResolver.js
+++ b/spec/propertyNameResolver.js
@@ -1,0 +1,33 @@
+/// <reference path="../typings/tsd.d.ts" />
+// Disabled multiline warning, we're fine with ES5
+// jshint -W043
+
+var sampleFile = "\
+using System;\n\
+\n\
+namespace MyNamespace.Domain\n\
+{\n\
+    public class MyPoco\n\
+    {\n\
+        public int SomeInt { get; set; }\n\
+    }\n\
+}\n";
+
+var expectedOutput = "export interface MyPoco {\n\
+	someInt: number;\n\
+}\n";
+
+var pocoGen = require('../index.js');
+
+describe('typescript-cs-poco', function() {
+	it('should use the propertyNameResolver option correctly', function() {
+		var result = pocoGen(sampleFile, { propertyNameResolver : _propertyNameResolver });
+        
+        expect(result).toEqual(expectedOutput);
+		
+		
+		function _propertyNameResolver(propertyName) {
+			return propertyName[0].toLowerCase() + propertyName.substring(1);
+		}
+	});
+});

--- a/spec/propertyNameResolver.js
+++ b/spec/propertyNameResolver.js
@@ -9,12 +9,16 @@ namespace MyNamespace.Domain\n\
 {\n\
     public class MyPoco\n\
     {\n\
-        public int SomeInt { get; set; }\n\
+        public int Id { get; set; }\n\
+        public string Name { get; set; }\n\
+        public string Title { get; set; }\n\
     }\n\
 }\n";
 
-var expectedOutput = "export interface MyPoco {\n\
-	someInt: number;\n\
+var expectedOutput = "interface MyPoco {\n\
+    id: number;\n\
+    name: string;\n\
+    title: string;\n\
 }\n";
 
 var pocoGen = require('../index.js');


### PR DESCRIPTION
This change allows passing a function to transform property names to the
module. This allows for camel casing the property names or any other
convention where C# property names and JavaScript property names differ.