### PR TITLE
Issue with enum regex and adding case for System.DateTime

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,11 +125,6 @@ function generateEnum(enumName, input, options) {
         var entryName = entryResult[1];
         var entryValue = entryResult[2];
 
-        // Skip attributes, might be a cleaner way in the regex
-        if (entryName.indexOf('[') !== -1) {
-            continue;
-        }
-
         if (!entryValue) {
             entryValue = lastIndex;
 

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function generateInterface(className, input, options) {
 }
 
 function generateEnum(enumName, input, options) {
-    var entryRegex = /([^\s,]+)\s*=?\s*(\d+)?,?/gm;
+    var entryRegex = /([^\s,\]]+)\s*=?\s*(\d+)?[,|\s|}]$/gm;
     var definition = 'enum ' + enumName + ' {\n    ';
 
     var entryResult;

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ typeTranslation.long = 'number';
 typeTranslation.decimal = 'number';
 typeTranslation.bool = 'boolean';
 typeTranslation.DateTime = 'string';
+typeTranslation["System.DateTime"] = 'string';
 typeTranslation.Guid = 'string';
 typeTranslation.JObject = 'any';
 typeTranslation.string = 'string';
@@ -43,8 +44,10 @@ function generateInterface(className, input, options) {
 
     if (options && options.dateTimeToDate) {
       typeTranslation.DateTime = 'Date';
+      typeTranslation["System.DateTime"] = 'Date';
     } else {
       typeTranslation.DateTime = 'string';
+      typeTranslation["System.DateTime"] = 'string';
     }
 
     while (!!(propertyResult = propertyRegex.exec(input))) {

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function generateInterface(className, input, options) {
 }
 
 function generateEnum(enumName, input, options) {
-    var entryRegex = /([^\s,\]]+)\s*=?\s*(\d+)?[,|\s|}]$/gm;
+    var entryRegex = /([^\s,\]\[]+)\s*=?\s*(\d+)?[,|\s]/gm;
     var definition = 'enum ' + enumName + ' {\n    ';
 
     var entryResult;

--- a/spec/dateTimeToDateOption.js
+++ b/spec/dateTimeToDateOption.js
@@ -43,6 +43,7 @@ namespace MyNamespace.Domain\n\
         public SomeOtherPoco AnotherPoco {get; set;}\n\
         public List<SomeOtherPoco> MorePocos {get; set;}\n\
         public SomeOtherPoco[] ArrayPocos {get; set;}\n\
+        public System.DateTime SomeSpecifiedDateTime {get; set;}\n\
     }\n\
 }\n";
 
@@ -60,6 +61,7 @@ var expectedOutput = "interface MyPoco {\n\
     AnotherPoco: SomeOtherPoco;\n\
     MorePocos: SomeOtherPoco[];\n\
     ArrayPocos: SomeOtherPoco[];\n\
+    SomeSpecifiedDateTime: Date;\n\
 }\n";
 
 var pocoGen = require('../index.js');
@@ -69,7 +71,7 @@ describe('typescript-cs-poco', function() {
 		var result = pocoGen(sampleFile, {
             dateTimeToDate: true
         });
-        
+
         expect(result).toEqual(expectedOutput);
 	});
 });


### PR DESCRIPTION
Fixing issue where enum has a space in its string causing an extra enum type to be created that has an unbounded " mark.

Case:

        public enum BankType
        {                
                Default,
                
                [System.Xml.Serialization.XmlEnumAttribute("US-Savings ")]
                USSavings,
                
                [System.Xml.Serialization.XmlEnumAttribute("GB-Loan ")]
                GBLoan,
                
                [System.Xml.Serialization.XmlEnumAttribute("FR-Lender ")]
                FRLender
        }

Produces:

        declare enum BankType {
                Default = 0,
                ")] = 1,
                USSavings = 2,
                ")] = 3,
                GBLoan = 4,
                ")] = 5,
                FRLender = 6
        }

The regex in my fork only finds the enum types and so the check to see if it contains a "[" is not needed.

-----------------------------------------------
Adding a case for when referencing System.DateTime by System.DateTime instead of DateTime.